### PR TITLE
Feat: bump webnative to v0.36.3 and update directory usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "uint8arrays": "^3.1.0",
         "web-vitals": "^2.1.4",
         "webnative": "^0.36.3",
-        "webnative-walletauth": "fission-codes/webnative-walletauth#avivash/bump-webnative-to-0.36.3"
+        "webnative-walletauth": "^0.2.1"
       },
       "devDependencies": {
         "@types/qrcode-svg": "^1.1.1",
@@ -44824,7 +44824,7 @@
     },
     "webnative-walletauth": {
       "version": "git+ssh://git@github.com/fission-codes/webnative-walletauth.git#ff88f33de60a782088bb44464a49e6e22b681166",
-      "from": "webnative-walletauth@fission-codes/webnative-walletauth#avivash/bump-webnative-to-0.36.3",
+      "from": "webnative-walletauth@^0.2.1",
       "requires": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "uint8arrays": "^3.1.0",
         "web-vitals": "^2.1.4",
         "webnative": "^0.36.3",
-        "webnative-walletauth": "file:../webnative-walletauth"
+        "webnative-walletauth": "fission-codes/webnative-walletauth#avivash/bump-webnative-to-0.36.3"
       },
       "devDependencies": {
         "@types/qrcode-svg": "^1.1.1",
@@ -41,29 +41,6 @@
         "react-app-rewired": "^2.2.1",
         "tailwindcss": "^3.1.8",
         "typescript": "^4.8.3"
-      }
-    },
-    "../webnative-walletauth": {
-      "version": "0.2.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/hashes": "^1.1.2",
-        "@noble/secp256k1": "^1.6.3",
-        "eip1193-provider": "^1.0.1",
-        "tweetnacl": "^1.0.3",
-        "uint8arrays": "^3.1.0"
-      },
-      "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.10.0",
-        "@typescript-eslint/parser": "^5.10.0",
-        "esbuild": "^0.15.7",
-        "eslint": "^8.7.0",
-        "events": "^3.3.0",
-        "rimraf": "^3.0.2",
-        "typescript": "^4.5.5"
-      },
-      "peerDependencies": {
-        "webnative": "^0.36.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3287,6 +3264,37 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@json-rpc-tools/provider": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
+      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "@json-rpc-tools/utils": "^1.7.6",
+        "axios": "^0.21.0",
+        "safe-json-utils": "^1.1.1",
+        "ws": "^7.4.0"
+      }
+    },
+    "node_modules/@json-rpc-tools/types": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
+      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "node_modules/@json-rpc-tools/utils": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
+      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "@json-rpc-tools/types": "^1.7.6",
+        "@pedrouid/environment": "^1.0.1"
+      }
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
@@ -3503,6 +3511,28 @@
         "eslint-scope": "5.1.1"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3534,6 +3564,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pedrouid/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.7",
@@ -7170,6 +7205,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -9749,6 +9792,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/eip1193-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
+      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
+      "dependencies": {
+        "@json-rpc-tools/provider": "^1.5.5"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.8",
@@ -15901,6 +15952,11 @@
       "engines": {
         "node": ">=10.21.0"
       }
+    },
+    "node_modules/keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -22730,6 +22786,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "node_modules/safe-json-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
+      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
+    },
     "node_modules/safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -25329,8 +25390,19 @@
       }
     },
     "node_modules/webnative-walletauth": {
-      "resolved": "../webnative-walletauth",
-      "link": true
+      "version": "0.2.1",
+      "resolved": "git+ssh://git@github.com/fission-codes/webnative-walletauth.git#ff88f33de60a782088bb44464a49e6e22b681166",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "@noble/secp256k1": "^1.6.3",
+        "eip1193-provider": "^1.0.1",
+        "tweetnacl": "^1.0.3",
+        "uint8arrays": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webnative": "^0.36.3"
+      }
     },
     "node_modules/webnative/node_modules/multiformats": {
       "version": "10.0.2",
@@ -28399,6 +28471,34 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@json-rpc-tools/provider": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
+      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
+      "requires": {
+        "@json-rpc-tools/utils": "^1.7.6",
+        "axios": "^0.21.0",
+        "safe-json-utils": "^1.1.1",
+        "ws": "^7.4.0"
+      }
+    },
+    "@json-rpc-tools/types": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
+      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
+      "requires": {
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "@json-rpc-tools/utils": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
+      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
+      "requires": {
+        "@json-rpc-tools/types": "^1.7.6",
+        "@pedrouid/environment": "^1.0.1"
+      }
+    },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
@@ -28557,6 +28657,16 @@
         "eslint-scope": "5.1.1"
       }
     },
+    "@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ=="
+    },
+    "@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -28579,6 +28689,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@pedrouid/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.7",
@@ -31334,6 +31449,14 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w=="
     },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -33243,6 +33366,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "eip1193-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
+      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
+      "requires": {
+        "@json-rpc-tools/provider": "^1.5.5"
+      }
     },
     "ejs": {
       "version": "3.1.8",
@@ -37754,6 +37885,11 @@
         "one-webcrypto": "^1.0.3",
         "uint8arrays": "^3.0.0"
       }
+    },
+    "keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -42668,6 +42804,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "safe-json-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
+      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
+    },
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -44682,19 +44823,13 @@
       }
     },
     "webnative-walletauth": {
-      "version": "file:../webnative-walletauth",
+      "version": "git+ssh://git@github.com/fission-codes/webnative-walletauth.git#ff88f33de60a782088bb44464a49e6e22b681166",
+      "from": "webnative-walletauth@fission-codes/webnative-walletauth#avivash/bump-webnative-to-0.36.3",
       "requires": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
-        "@typescript-eslint/eslint-plugin": "^5.10.0",
-        "@typescript-eslint/parser": "^5.10.0",
         "eip1193-provider": "^1.0.1",
-        "esbuild": "^0.15.7",
-        "eslint": "^8.7.0",
-        "events": "^3.3.0",
-        "rimraf": "^3.0.2",
         "tweetnacl": "^1.0.3",
-        "typescript": "^4.5.5",
         "uint8arrays": "^3.1.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,8 @@
         "recoil-nexus": "^0.4.0",
         "uint8arrays": "^3.1.0",
         "web-vitals": "^2.1.4",
-        "webnative": "^0.35.1",
-        "webnative-walletauth": "^0.2.0"
+        "webnative": "^0.36.3",
+        "webnative-walletauth": "file:../webnative-walletauth"
       },
       "devDependencies": {
         "@types/qrcode-svg": "^1.1.1",
@@ -41,6 +41,29 @@
         "react-app-rewired": "^2.2.1",
         "tailwindcss": "^3.1.8",
         "typescript": "^4.8.3"
+      }
+    },
+    "../webnative-walletauth": {
+      "version": "0.2.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "@noble/secp256k1": "^1.6.3",
+        "eip1193-provider": "^1.0.1",
+        "tweetnacl": "^1.0.3",
+        "uint8arrays": "^3.1.0"
+      },
+      "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.10.0",
+        "@typescript-eslint/parser": "^5.10.0",
+        "esbuild": "^0.15.7",
+        "eslint": "^8.7.0",
+        "events": "^3.3.0",
+        "rimraf": "^3.0.2",
+        "typescript": "^4.5.5"
+      },
+      "peerDependencies": {
+        "webnative": "^0.36.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3264,37 +3287,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@json-rpc-tools/provider": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
-      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "@json-rpc-tools/utils": "^1.7.6",
-        "axios": "^0.21.0",
-        "safe-json-utils": "^1.1.1",
-        "ws": "^7.4.0"
-      }
-    },
-    "node_modules/@json-rpc-tools/types": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
-      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "keyvaluestorage-interface": "^1.0.0"
-      }
-    },
-    "node_modules/@json-rpc-tools/utils": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
-      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "@json-rpc-tools/types": "^1.7.6",
-        "@pedrouid/environment": "^1.0.1"
-      }
-    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
@@ -3511,28 +3503,6 @@
         "eslint-scope": "5.1.1"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.4.tgz",
-      "integrity": "sha512-+PYsVPrTSqtVjatKt2A/Proukn2Yrz61OBThOCKErc5w2/r1Fh37vbDv0Eah7pyNltrmacjwTvdw3JoR+WE4TA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
-    "node_modules/@noble/secp256k1": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3564,11 +3534,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@pedrouid/environment": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.7",
@@ -7205,14 +7170,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -9792,14 +9749,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
-    },
-    "node_modules/eip1193-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
-      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
-      "dependencies": {
-        "@json-rpc-tools/provider": "^1.5.5"
-      }
     },
     "node_modules/ejs": {
       "version": "3.1.8",
@@ -15952,11 +15901,6 @@
       "engines": {
         "node": ">=10.21.0"
       }
-    },
-    "node_modules/keyvaluestorage-interface": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
-      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -22786,11 +22730,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "node_modules/safe-json-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
-      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
-    },
     "node_modules/safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -25359,9 +25298,9 @@
       }
     },
     "node_modules/webnative": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.1.tgz",
-      "integrity": "sha512-ddd4FK0H1rr5rn4bOgtPiYDniM5kR28PdGawLkowzsZDOX2cZhJNxk98fPPuHO9K9+QbEVfR21Mh/RJmF+74Ug==",
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.36.3.tgz",
+      "integrity": "sha512-MucN6ydnyY5E8GczuARAWXSOn3+yjXKSLNTIPeJhcFmZpxPBDRfpZ0SpKJjKWtVLNiEaUQibeiKsIYDfij/wIQ==",
       "dependencies": {
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-pb": "^3.0.1",
@@ -25390,19 +25329,8 @@
       }
     },
     "node_modules/webnative-walletauth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/webnative-walletauth/-/webnative-walletauth-0.2.0.tgz",
-      "integrity": "sha512-3A9hpwsH4alSmdlbCJ2gCO3DesPKJSvmh1gUtrf67U1CNRV573dHAchpz+hvzIjCWo4wJwVM7X/KkEJf35dPvQ==",
-      "dependencies": {
-        "@noble/hashes": "^1.1.2",
-        "@noble/secp256k1": "^1.6.3",
-        "eip1193-provider": "^1.0.1",
-        "tweetnacl": "^1.0.3",
-        "uint8arrays": "^3.1.0"
-      },
-      "peerDependencies": {
-        "webnative": "^0.35.0"
-      }
+      "resolved": "../webnative-walletauth",
+      "link": true
     },
     "node_modules/webnative/node_modules/multiformats": {
       "version": "10.0.2",
@@ -28471,34 +28399,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "@json-rpc-tools/provider": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
-      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
-      "requires": {
-        "@json-rpc-tools/utils": "^1.7.6",
-        "axios": "^0.21.0",
-        "safe-json-utils": "^1.1.1",
-        "ws": "^7.4.0"
-      }
-    },
-    "@json-rpc-tools/types": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
-      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
-      "requires": {
-        "keyvaluestorage-interface": "^1.0.0"
-      }
-    },
-    "@json-rpc-tools/utils": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
-      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
-      "requires": {
-        "@json-rpc-tools/types": "^1.7.6",
-        "@pedrouid/environment": "^1.0.1"
-      }
-    },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
@@ -28657,16 +28557,6 @@
         "eslint-scope": "5.1.1"
       }
     },
-    "@noble/hashes": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.4.tgz",
-      "integrity": "sha512-+PYsVPrTSqtVjatKt2A/Proukn2Yrz61OBThOCKErc5w2/r1Fh37vbDv0Eah7pyNltrmacjwTvdw3JoR+WE4TA=="
-    },
-    "@noble/secp256k1": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw=="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -28689,11 +28579,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@pedrouid/environment": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.7",
@@ -31449,14 +31334,6 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w=="
     },
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "requires": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -33366,14 +33243,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
-    },
-    "eip1193-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
-      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
-      "requires": {
-        "@json-rpc-tools/provider": "^1.5.5"
-      }
     },
     "ejs": {
       "version": "3.1.8",
@@ -37885,11 +37754,6 @@
         "one-webcrypto": "^1.0.3",
         "uint8arrays": "^3.0.0"
       }
-    },
-    "keyvaluestorage-interface": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
-      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -42804,11 +42668,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "safe-json-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
-      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
-    },
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -44788,9 +44647,9 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "webnative": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.1.tgz",
-      "integrity": "sha512-ddd4FK0H1rr5rn4bOgtPiYDniM5kR28PdGawLkowzsZDOX2cZhJNxk98fPPuHO9K9+QbEVfR21Mh/RJmF+74Ug==",
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.36.3.tgz",
+      "integrity": "sha512-MucN6ydnyY5E8GczuARAWXSOn3+yjXKSLNTIPeJhcFmZpxPBDRfpZ0SpKJjKWtVLNiEaUQibeiKsIYDfij/wIQ==",
       "requires": {
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-pb": "^3.0.1",
@@ -44823,14 +44682,19 @@
       }
     },
     "webnative-walletauth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/webnative-walletauth/-/webnative-walletauth-0.2.0.tgz",
-      "integrity": "sha512-3A9hpwsH4alSmdlbCJ2gCO3DesPKJSvmh1gUtrf67U1CNRV573dHAchpz+hvzIjCWo4wJwVM7X/KkEJf35dPvQ==",
+      "version": "file:../webnative-walletauth",
       "requires": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
+        "@typescript-eslint/eslint-plugin": "^5.10.0",
+        "@typescript-eslint/parser": "^5.10.0",
         "eip1193-provider": "^1.0.1",
+        "esbuild": "^0.15.7",
+        "eslint": "^8.7.0",
+        "events": "^3.3.0",
+        "rimraf": "^3.0.2",
         "tweetnacl": "^1.0.3",
+        "typescript": "^4.5.5",
         "uint8arrays": "^3.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "recoil-nexus": "^0.4.0",
     "uint8arrays": "^3.1.0",
     "web-vitals": "^2.1.4",
-    "webnative": "^0.35.1",
-    "webnative-walletauth": "^0.2.0"
+    "webnative": "^0.36.3",
+    "webnative-walletauth": "file:../webnative-walletauth"
   },
   "scripts": {
     "dev": "GENERATE_SOURCEMAP=false PORT=4001 react-app-rewired start",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "uint8arrays": "^3.1.0",
     "web-vitals": "^2.1.4",
     "webnative": "^0.36.3",
-    "webnative-walletauth": "fission-codes/webnative-walletauth#avivash/bump-webnative-to-0.36.3"
+    "webnative-walletauth": "^0.2.1"
   },
   "scripts": {
     "dev": "GENERATE_SOURCEMAP=false PORT=4001 react-app-rewired start",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "uint8arrays": "^3.1.0",
     "web-vitals": "^2.1.4",
     "webnative": "^0.36.3",
-    "webnative-walletauth": "file:../webnative-walletauth"
+    "webnative-walletauth": "fission-codes/webnative-walletauth#avivash/bump-webnative-to-0.36.3"
   },
   "scripts": {
     "dev": "GENERATE_SOURCEMAP=false PORT=4001 react-app-rewired start",

--- a/src/lib/account-settings.ts
+++ b/src/lib/account-settings.ts
@@ -31,9 +31,15 @@ interface AvatarFile extends PuttableUnixTree, WNFile {
   };
 }
 
-export const ACCOUNT_SETTINGS_DIR = ["private", "settings"];
-const AVATAR_DIR = [...ACCOUNT_SETTINGS_DIR, "avatars"];
-const AVATAR_ARCHIVE_DIR = [...AVATAR_DIR, "archive"];
+export const ACCOUNT_SETTINGS_DIR = wn.path.directory("private", "settings");
+const AVATAR_DIR = wn.path.combine(
+  ACCOUNT_SETTINGS_DIR,
+  wn.path.directory("avatars")
+);
+const AVATAR_ARCHIVE_DIR = wn.path.combine(
+  AVATAR_DIR,
+  wn.path.directory("archive")
+);
 const AVATAR_FILE_NAME = "avatar";
 const FILE_SIZE_LIMIT = 20;
 
@@ -43,13 +49,13 @@ const FILE_SIZE_LIMIT = 20;
 const archiveOldAvatar = async (): Promise<void> => {
   const fs = getRecoil(filesystemStore);
   // Return if user has not uploaded an avatar yet
-  const avatarDirExists = await fs.exists(wn.path.file(...AVATAR_DIR));
+  const avatarDirExists = await fs.exists(AVATAR_DIR);
   if (!avatarDirExists) {
     return;
   }
 
   // Find the filename of the old avatar
-  const path = wn.path.directory(...AVATAR_DIR);
+  const path = AVATAR_DIR;
   const links = await fs.ls(path);
   const oldAvatarFileName = Object.keys(links).find((key) =>
     key.includes(AVATAR_FILE_NAME)
@@ -60,8 +66,11 @@ const archiveOldAvatar = async (): Promise<void> => {
   }`;
 
   // Move old avatar to archive dir
-  const fromPath = wn.path.file(...AVATAR_DIR, oldAvatarFileName);
-  const toPath = wn.path.file(...AVATAR_ARCHIVE_DIR, archiveFileName);
+  const fromPath = wn.path.combine(AVATAR_DIR, wn.path.file(oldAvatarFileName));
+  const toPath = wn.path.combine(
+    AVATAR_ARCHIVE_DIR,
+    wn.path.file(archiveFileName)
+  );
   await fs.mv(fromPath, toPath);
 
   // Announce the changes to the server
@@ -81,14 +90,14 @@ export const getAvatarFromWNFS = async (): Promise<void> => {
     setRecoil(accountSettingsStore, { ...accountSettings, loading: true });
 
     // If the avatar dir doesn't exist, silently fail and let the UI handle it
-    const avatarDirExists = await fs.exists(wn.path.file(...AVATAR_DIR));
+    const avatarDirExists = await fs.exists(AVATAR_DIR);
     if (!avatarDirExists) {
       setRecoil(accountSettingsStore, { ...accountSettings, loading: false });
       return;
     }
 
     // Find the file that matches the AVATAR_FILE_NAME
-    const path = wn.path.directory(...AVATAR_DIR);
+    const path = AVATAR_DIR;
     const links = await fs.ls(path);
     const avatarName = Object.keys(links).find((key) =>
       key.includes(AVATAR_FILE_NAME)
@@ -100,7 +109,9 @@ export const getAvatarFromWNFS = async (): Promise<void> => {
       return;
     }
 
-    const file = await fs.get(wn.path.file(...AVATAR_DIR, `${avatarName}`));
+    const file = await fs.get(
+      wn.path.combine(AVATAR_DIR, wn.path.file(`${avatarName}`))
+    );
 
     // The CID for private files is currently located in `file.header.content`
     const cid = (file as AvatarFile).header.content.toString();
@@ -166,7 +177,7 @@ export const uploadAvatarToWNFS = async (image: File): Promise<void> => {
 
     // Create a sub directory and add the avatar
     await fs.write(
-      wn.path.file(...AVATAR_DIR, updatedImage.name),
+      wn.path.combine(AVATAR_DIR, wn.path.file(updatedImage.name)),
       await fileToUint8Array(updatedImage)
     );
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -63,7 +63,7 @@ const handleProgram = async (program: wn.Program) => {
 
   if (program.session) {
     // Create directory for Account Settings
-    await program.session.fs.mkdir(wn.path.directory(...ACCOUNT_SETTINGS_DIR));
+    await program.session.fs.mkdir(ACCOUNT_SETTINGS_DIR);
 
     // ✅ Authenticated
     setRecoil(sessionStore, {


### PR DESCRIPTION
# Description

- Bump `webnative` to `0.36.3`(also updated inside [webnative-walletauth](https://github.com/fission-codes/webnative-walletauth/pull/17))
- Update account-settings and gallery directory definitions to match WAT(using `wn.path.directory`/`wn.patch.combine`)

## Link to issue

https://github.com/orgs/fission-codes/projects/14/views/26?pane=issue&itemId=21175565

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

